### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 为以后将服务设计为**水平可扩展**的服务准备，将整个服务拆分为3个进程。<br>
 实现基本功能后的目标是将每个服务设计为可水平扩展的集群，并且重点放在架构上的优化而不是逻辑功能上。<br>
 
-##**一、QuicksStart**:
+## **一、QuicksStart**:
 **(a)启动服务器:**<br>
 
  1. 使用intellij `maven方式`导入该工程，执行`mvn clean compile`<br>
@@ -22,17 +22,17 @@
 
  - 按照quickstart流程依次启动服务器后，再启动client模块的下的客户端(Client类)，服务便会自动执行注册，登录的流程，并每隔100ms给自己发送聊天信息。<br>
 
-##**二、添加业务逻辑**<br>
+## **二、添加业务逻辑**<br>
  - `协议流动方式介绍`：客户端先连接gate，gate服务根据客户端发送的协议类型转发到auth服或者logic，到达auth或者logic之后，IO线程将消息dispatch到后端worker线程处理。<br>
  - `定制业务逻辑`：<br>
     - 只需在三个地方注册协议：protobuf模块的**ParseRegistryMap**，gate模块的**TransferHandlerMap**，最后是根据协议类型在auth模块或者logic模块的**HandlerManager**注册即可。注意：HandlerManager注册的是协议最终处理的业务逻辑。<br>
     - 在protobuf模块对应**.proto**文件添加你自己定义的协议，执行**proto.bat**即可生成对应pb文件。<br>
 
-##**三、压力测试**<br>
+## **三、压力测试**<br>
  1. client模块中的`client.Client`类提供了进行压力测试的方法，可以修改启动客户端连接的数量`Client.clientNum`，以及每秒向服务器发送的协议的频率`Client.frequency`进行压力测试。<br>
  2. CPU 8核E3-1231v3， 每个服务分配1G的堆内存，启动5000个客户端后(需要一定时间)，不停给自己发送单聊协议，发现auth、logic、gate服务占用的cpu非常低，客户端能够立即收到响应。对应的TPS统计将在后续加入。<br>
 
-##**四、水平扩展思路(processing)**<br>
+## **四、水平扩展思路(processing)**<br>
 实际上最简单的做法，就是利用`消息中间件`对服务之间的调用进行**解耦**，这里以消息中间件RocketMQ为例子：
 ```
     client(Producer) ->  gate(Consumer)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
